### PR TITLE
Enhance AsyncExtension

### DIFF
--- a/src/NetMQ.Tests/AsyncTests.cs
+++ b/src/NetMQ.Tests/AsyncTests.cs
@@ -28,20 +28,28 @@ namespace NetMQ.Tests
                     var (routingKey, _) = await server.ReceiveRoutingKeyAsync();
                     var (message, _) = await server.ReceiveFrameStringAsync();
 
-                    Assert.Equal(message, "Hello");
+                    Assert.Equal("Hello", message);
 
                     server.SendMoreFrame(routingKey);
                     server.SendFrame(new[] { (byte) 0 });
 
                     var (bytes, _) = await client.ReceiveFrameBytesAsync();
 
-                    Assert.Equal(bytes[0], 0);
+                    Assert.Equal(new[] { (byte) 0 }, bytes);
                 }
             }
 
             using (var runtime = new NetMQRuntime())
             {
-                runtime.Run(ReceiveAsync());
+                var t = ReceiveAsync();
+                runtime.Run(t);
+
+                if (t.IsFaulted && t.Exception is AggregateException exc)
+                {
+                    throw exc.GetBaseException();
+                }
+            }
+        }        
             }
         }
     }

--- a/src/NetMQ/AsyncReceiveExtensions.cs
+++ b/src/NetMQ/AsyncReceiveExtensions.cs
@@ -19,6 +19,41 @@ namespace NetMQ
     [SuppressMessage("ReSharper", "UnusedMethodReturnValue.Global")]
     public static class AsyncReceiveExtensions
     {
+        #region Receiving frames as a multipart message
+
+        /// <summary>
+        /// Receive a single frame from <paramref name="socket"/>, asynchronously.
+        /// </summary>
+        /// <param name="socket">The socket to receive from.</param>
+        /// <param name="expectedFrameCount">Specifies the initial capacity of the <see cref="List{T}"/> used
+        /// to buffer results. If the number of frames is known, set it here. If more frames arrive than expected,
+        /// an extra allocation will occur, but the result will still be correct.</param>
+        /// <param name="cancellationToken">The token used to propagate notification that this operation should be canceled.</param>
+        /// <returns>The content of the received message.</returns>
+        [NotNull]
+        public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
+            [NotNull] this NetMQSocket socket, 
+            int expectedFrameCount = 4,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var message = new NetMQMessage(expectedFrameCount);
+
+            while (true)
+            {
+                (byte[] bytes, bool more) = await socket.ReceiveFrameBytesAsync(cancellationToken);
+                message.Append(bytes);
+
+                if (!more)
+                {
+                    break;
+                }
+            }
+
+            return message;
+        }
+
+        #endregion
+
         #region Receiving a frame as a byte array
 
         /// <summary>

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -570,8 +570,6 @@ namespace NetMQ
         public void Stop()
         {
             CheckDisposed();
-            if (!IsRunning)
-                throw new InvalidOperationException("NetMQPoller is not running");
 
             // Signal the poller to stop
             m_stopSignaler.RequestStop();


### PR DESCRIPTION
This PR adds some feature to `NetMQ.AsyncReceiveExtensions` as below.

- Added `.RecevieMultipartMessageAsync()` to receive a multi part message easily.
- Added `CancellationToken` argument to async extension methods in `AsyncReceiveExtensions`.
- Fixed `AsyncTest` to indicate assertion properly.
- Removed state check on `NetMQPoller.Stop()` to prevent freezing during unit testing.