### PR TITLE
Guard m_mechanism against null in handshake processing

### DIFF
--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -1172,14 +1172,19 @@ namespace NetMQ.Core.Transports
 
         PushMsgResult ProcessHandshakeCommand (ref Msg msg)
         {
+            // m_mechanism may be torn down concurrently when the engine is
+            // cancelled/closed mid-handshake; treat that as a handshake error.
+            if (m_mechanism == null)
+                return PushMsgResult.Error;
+
             var result = m_mechanism.ProcessHandshakeCommand(ref msg);
-            if (result == PushMsgResult.Ok) 
+            if (result == PushMsgResult.Ok)
             {
                 if (m_mechanism.Status == MechanismStatus.Ready)
                     MechanismReady();
                 else if (m_mechanism.Status == MechanismStatus.Error)
                     return PushMsgResult.Error;
-                
+
                 if (m_sendingState == SendState.Idle)
                 {
                     m_sendingState = SendState.Active;
@@ -1189,9 +1194,12 @@ namespace NetMQ.Core.Transports
 
             return result;
         }
-        
+
         void MechanismReady ()
         {
+            if (m_mechanism == null)
+                return;
+
             if (m_options.HeartbeatInterval > 0)
             {
                 m_ioObject.AddTimer(m_options.HeartbeatInterval, HeartbeatIntervalTimerId);


### PR DESCRIPTION
## Summary

Add early-return null guards at the two entry points where `m_mechanism` is dereferenced during handshake — `ProcessHandshakeCommand` and `MechanismReady` — to defuse a production NRE crash on Heimdall validators.

## Stack trace from production

```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at NetMQ.Core.Transports.StreamEngine.MechanismReady()
   at NetMQ.Core.Transports.StreamEngine.ProcessHandshakeCommand(Msg& msg)
   at NetMQ.Core.Transports.StreamEngine.ProcessInput()
   at NetMQ.Core.Utils.Proactor.Loop()
```

It fires when a 1s broadcast cancellation in `Libplanet.Net.NetMQTransport.SendMessageAsync` propagates into the handshake path of an engine whose `m_mechanism` is being torn down concurrently. See planetarium/libplanet#4050 for the full operational analysis.

## Why a fork-local patch

zeromq/netmq has a near-equivalent fix (`0a1b70d` "Add extra null check in StreamEngine", 2025-06-02), but it guards a `m_session.Detach(bool)` overload that does not exist in this fork — `Error()` here calls the parameter-less `Detach()`. The two `StreamEngine.cs` files have drifted far enough since 2021 that a direct cherry-pick is not possible. This patch addresses the specific NRE site observed in production rather than every site upstream guards.

A wholesale rebase of this fork onto upstream remains a separate, larger discussion (planetarium/libplanet#4050 option (b)).

## Behavior

- `ProcessHandshakeCommand`: when `m_mechanism` is null, return `PushMsgResult.Error` so the engine tears down through the normal handshake-error path.
- `MechanismReady`: when `m_mechanism` is null, return silently — heartbeat and identity setup are no-ops without a mechanism.

## Test plan

- [x] `dotnet build src/NetMQ.sln /p:Configuration=Release` passes (0 errors).
- [ ] Existing `NetMQ.Tests` suite (run via maintainer's CI).
- [ ] Once tagged + published, verify Heimdall validator pods stop logging `Exit 139` for >=24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)