### PR TITLE
Modernize CI test target frameworks (net6.0 + net8.0)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,38 +2,41 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  ununtu:
+  ubuntu:
     runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - run: dotnet restore src/NetMQ.sln
-    - name: build 
+    - name: build
       run: dotnet build src/NetMQ.sln /p:Configuration=Release /verbosity:minimal
-    - name: test netcoreapp3.1
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f netcoreapp3.1 src/NetMQ.Tests/NetMQ.Tests.csproj
-    - name: test netcoreapp2.1
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f netcoreapp2.1 src/NetMQ.Tests/NetMQ.Tests.csproj
+    - name: test net6.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net6.0 src/NetMQ.Tests/NetMQ.Tests.csproj
+    - name: test net8.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net8.0 src/NetMQ.Tests/NetMQ.Tests.csproj
   windows:
     runs-on: windows-latest
+    env:
+      DOTNET_NOLOGO: true
     steps:
-    - uses: actions/checkout@v2
-    - name: Install codecov
-      run: |
-        choco install opencover.portable 
-        choco install codecov
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - run: dotnet restore src/NetMQ.sln
-    - name: build 
+    - name: build
       run: dotnet build src/NetMQ.sln /p:Configuration=Release /verbosity:minimal
-    - name: test netcoreapp2.1
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f netcoreapp2.1 src\NetMQ.Tests\NetMQ.Tests.csproj
-    - name: test netcoreapp3.1
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f netcoreapp3.1 src\NetMQ.Tests\NetMQ.Tests.csproj
+    - name: test net6.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net6.0 src\NetMQ.Tests\NetMQ.Tests.csproj
+    - name: test net8.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net8.0 src\NetMQ.Tests\NetMQ.Tests.csproj
     - name: test net47
       run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net47 src\NetMQ.Tests\NetMQ.Tests.csproj
-    - name: coverage
-      run: |
-        OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --no-build --configuration Release -f netcoreapp2.1 --logger:trx;LogFileName=results.trx /p:DebugType=full src\NetMQ.Tests\NetMQ.Tests.csproj" -filter:"+[NetMQ*]* -[NetMQ.Tests*]*" -output:".\NetMQ_coverage.xml" -oldStyle
-        codecov -f "NetMQ_coverage.xml"
-       
-       
-

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -8,7 +8,13 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);netcoreapp1.0;portable-net45+win8</PackageTargetFallback>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net47</TargetFrameworks>
+    <!-- ExceptionTests.cs serializes a NetMQException via BinaryFormatter to
+         verify ISerializable plumbing. BinaryFormatter is obsolete in net8.0
+         (SYSLIB0011 is treated as an error by default) but the test itself is
+         still valid for verifying the legacy contract. -->
+    <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,8 +46,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

CI is currently red on every PR (including planetarium/netmq#6) because GitHub Actions runners no longer ship the .NET Core 2.1 / 3.1 runtimes that `NetMQ.Tests` targets:

```
You must install or update .NET to run this application.
Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
The following frameworks were found:
  8.0.6, 8.0.22 at /usr/share/dotnet/shared/Microsoft.NETCore.App
```

This PR moves the test project to net6.0 + net8.0 (keeping `net47` on Windows for the netfx code path) and installs matching SDKs explicitly via `actions/setup-dotnet`.

## Changes

- `NetMQ.Tests.csproj`
  - `TargetFrameworks`: `netcoreapp2.1;netcoreapp3.1;net47` -> `net6.0;net8.0;net47`
  - `Microsoft.NET.Test.Sdk`: `15.5.0` -> `17.8.0`
  - `Newtonsoft.Json`: `10.0.3` -> `13.0.3` (Test.Sdk 17.8 transitively requires `>= 13.0.1`; without bumping the floor pin we hit NU1605)
  - Added `<NoWarn>SYSLIB0011</NoWarn>` and `<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>` so the existing `BinaryFormatter`-based ISerializable test in `ExceptionTests.cs` still compiles on net8.0 (where SYSLIB0011 is treated as error by default).
- `.github/workflows/CI.yml`
  - Added `actions/setup-dotnet@v4` installing 6.0.x and 8.0.x.
  - Bumped `actions/checkout` v2 -> v4.
  - Replaced `netcoreapp2.1` / `netcoreapp3.1` test steps with `net6.0` / `net8.0`.
  - Dropped the OpenCover/codecov step — it was wired to a `netcoreapp2.1` test run that no longer exists. Restoring coverage with a modern collector (e.g. coverlet) can be a follow-up.
  - Renamed the typoed `ununtu` job to `ubuntu`.

## Verified locally

```
dotnet build src/NetMQ.Tests/NetMQ.Tests.csproj -c Release -f net6.0  # 0 errors
dotnet build src/NetMQ.Tests/NetMQ.Tests.csproj -c Release -f net8.0  # 0 errors
```

## Test plan

- [ ] Both `ubuntu` and `windows` jobs go green on this PR.
- [ ] After merging, planetarium/netmq#6's CI also goes green when its branch is rebased.

Refs: planetarium/libplanet#4050

🤖 Generated with [Claude Code](https://claude.com/claude-code)